### PR TITLE
Bigwigs Multiple Timers

### DIFF
--- a/Modules/Misc/BossMods.lua
+++ b/Modules/Misc/BossMods.lua
@@ -170,11 +170,11 @@ if BigWigsLoader then
 	end
 	
 	BigWigsLoader.RegisterMessage(owner, "BigWigs_StartBar", function(_, module, key, text, time)
-		stop(module, text)			
+		stop(module, text:lower())			
 		tinsert(Timers, {module = module, key = key, text = text:lower(), start = TMW.time, duration = time})
 	end)
 	BigWigsLoader.RegisterMessage(owner, "BigWigs_StopBar", function(_, module, text)
-		stop(module, text)  
+		stop(module, text:lower())  
 	end)
 	BigWigsLoader.RegisterMessage(owner, "BigWigs_StopBars", function(_, module)
 		stop(module)  


### PR DESCRIPTION
Fix BossMods:GetPullTimer() when multiple pull timers are sent with BigWigs installed. 

tinsert() uses  text = text:lower() as input so stop() must also use text:lower() as input.