### PR TITLE
Update Bossmods.lua

### DIFF
--- a/Modules/Misc/BossMods.lua
+++ b/Modules/Misc/BossMods.lua
@@ -223,7 +223,7 @@ if BigWigsLoader then
 	BigWigsLoader.RegisterMessage(owner, "BigWigs_StopNameplate", function(_, module, guid, key)
 		stop(module, nil, guid, key)
 	end)
-	BigWigsLoader.RegisterMessage(owner, "BigWigs_StopUnitNameplate", function(_, module, guid)
+	BigWigsLoader.RegisterMessage(owner, "BigWigs_ClearNameplate", function(_, module, guid)
 		stop(module, nil, guid)
 	end)
 

--- a/Modules/Misc/BossMods.lua
+++ b/Modules/Misc/BossMods.lua
@@ -84,7 +84,7 @@ if DBM then
 			error("Bad argument 'text' (nil value) for function DBM_GetTimeRemaining")
 		end
 
-		return 0, 0
+		return math.huge, math.huge
 	end
 
 	DBM_GetTimeRemainingBySpellID = function(spellID)
@@ -98,7 +98,7 @@ if DBM then
 			return remaining, expirationTime
 		end
 
-		return 0, 0
+		return math.huge, math.huge
 	end
 
 	hooksecurefunc(DBM, "StartCombat", function(DBM, mod, delay, event)
@@ -247,7 +247,7 @@ if BigWigsLoader then
 			error("Bad argument 'text' (nil value) for function BigWigs_GetTimeRemaining")
 		end
 
-		return 0, 0
+		return math.huge, math.huge
 	end
 	BigWigs_GetNameplateTimeRemaining = function(key)
 		local t


### PR DESCRIPTION
Update BossMods.lua to returns math.huge for unfound timer checks instead of 0, distinguish between queued spells and not found spells. 

Correct BigWigs Nameplates Message calls.